### PR TITLE
update to latest 3.3.4.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -22,7 +22,7 @@ The ``target-address`` and ``target-version`` are required for ViaProxy to start
 > warning: auth-method: openauthmod will be not functional for 1.7-1.7.10, Vanilla 1.8-1.19.3, 1.19.4-1.21.1, and Bedrock Edition.\
 > Reason: 1.7-1.7.10: OpenAuthMod is only available for 1.8.
 > Bedrock: Forge or Fabric don't support Bedrock Edition.\
-> OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
+> 1.19.4+: OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
 ### Connecting to ViaProxy in SRV mode
 To connect to ViaProxy in SRV mode you need a domain pointing to the IP of the server running ViaProxy.\
 The subdomain ``viaproxy.`` is required for it to work.\

--- a/README.MD
+++ b/README.MD
@@ -40,10 +40,6 @@ lenni0451.net_39999_c0.30-cpe.viaproxy.127-0-0-1.nip.io
 
 If the domain of a server contains an underscore you currently can't connect to it since ViaProxy uses the underscore as a separator.
 
-#### Geyser - usage for GeyserConnect
-find a existing instance of viaproxy.
-join with `address_port_version.viaproxy.hostname` on GeyserConnect. (turning on Bedrock/Geyser Server requires Geyser-Viaproxy installed on server side.).
-
 ## How to make a ViaProxy plugin
 ### viaproxy.yml
 ViaProxy plugins require a ``viaproxy.yml`` file in the root of the plugin jar.\

--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,10 @@ You have to replace ``0.0.0.0:<bind port>`` with the port you want ViaProxy to r
 The ``auth-method: openauthmod`` is optional and enables the [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) authentication. for 1.19.4 users, see the caution below.\
 The ``target-address`` and ``target-version`` are required for ViaProxy to start but don't do anything in SRV mode.
 > [!CAUTION]
-> warning: auth-method: openauthmod will be not functional for 1.7-1.7.10, Vanilla 1.8-1.19.3, 1.19.4-1.21.1, and Bedrock Edition.\ Reason: 1.7-1.7.10: OpenAuthMod is only available for 1.8.\ Bedrock: Forge or Fabric don't support Bedrock Edition.\ OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
+> warning: auth-method: openauthmod will be not functional for 1.7-1.7.10, Vanilla 1.8-1.19.3, 1.19.4-1.21.1, and Bedrock Edition.\
+> Reason: 1.7-1.7.10: OpenAuthMod is only available for 1.8.\ 
+> Bedrock: Forge or Fabric don't support Bedrock Edition.\
+> OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
 ### Connecting to ViaProxy in SRV mode
 To connect to ViaProxy in SRV mode you need a domain pointing to the IP of the server running ViaProxy.\
 The subdomain ``viaproxy.`` is required for it to work.\

--- a/README.MD
+++ b/README.MD
@@ -20,7 +20,7 @@ The ``auth-method: openauthmod`` is optional and enables the [OpenAuthMod](https
 The ``target-address`` and ``target-version`` are required for ViaProxy to start but don't do anything in SRV mode.
 > [!CAUTION]
 > warning: auth-method: openauthmod will be not functional for 1.7-1.7.10, Vanilla 1.8-1.19.3, 1.19.4-1.21.1, and Bedrock Edition.\
-> Reason: 1.7-1.7.10: OpenAuthMod is only available for 1.8.\ 
+> Reason: 1.7-1.7.10: OpenAuthMod is only available for 1.8.
 > Bedrock: Forge or Fabric don't support Bedrock Edition.\
 > OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
 ### Connecting to ViaProxy in SRV mode

--- a/README.MD
+++ b/README.MD
@@ -4,106 +4,22 @@ This plugin is only needed if you want to host a public SRV mode proxy instance.
 
 ## SRV ViaProxy
 ### Running ViaProxy in SRV mode
-> [!CAUTION]
-> This Option is meaningless because there is no proper authentication method for 1.19.4+ as OpenAuthMod discontinued and because ViaProxy was open source for 1 year is easier to use on client without their help. 
-use this option if you want to.
 
 To use the SRV mode in ViaProxy you have to start it through the config.\
-The config:
+Here are The config options require to make a Public SRV mode.
 ```
-# ViaProxy configuration file
-
-# The address ViaProxy should listen for connections.
-# This option is not reloadable.
 bind-address: 0.0.0.0:25568 # will translate to viaproxy.0-0-0-0.nip.io:25568
-
-# The address of the server ViaProxy should connect to.
-target-address: 0.0.0.0:25565 # This option is ignored as client handles it like <target-address>_<target-port>.viaproxy.<bind-address>.
-
-# The version ViaProxy should translate to. (See ViaProxy GUI for a list of versions)
-target-version: Auto Detect (1.7+ servers) # This option is ignored as client handles it like <target-address>_<target-port>_<target_version>.viaproxy.<bind-address>.
-
-# The connect timeout for backend server connections in milliseconds.
-connect-timeout: 8000
-
-# Proxy Online Mode allows you to see skins on online mode servers and use the signed chat features.
-# Enabling Proxy Online Mode requires your client to have a valid minecraft account.
-proxy-online-mode: false
-
-# The authentication method to use for joining the target server.
-# none: No authentication (Offline mode)
-# openauthmod: Requires the OpenAuthMod client mod (https://modrinth.com/mod/openauthmod)
-# account: Use an account for joining the target server. (Has to be configured in ViaProxy GUI)
-auth-method: OPENAUTHMOD # OPTIONAL.
-
-# The GUI account list index (0 indexed) of the account if the auth method is set to account.
-minecraft-account-index: 0
-
-# Use BetaCraft authentication for classic servers.
-# Enabling BetaCraft Auth allows you to join classic servers which have online mode enabled.
-betacraft-auth: false
-
-# URL of a SOCKS(4/5)/HTTP(S) proxy which will be used for backend server connections. Leave empty to connect directly.
-# Supported formats:
-# - type://address:port
-# - type://username:password@address:port
-backend-proxy-url: ''
-
-# Send HAProxy protocol messages to the target server.
-backend-haproxy: false
-
-# Read HAProxy protocol messages from client connections.
-frontend-haproxy: false
-
-# Enables sending signed chat messages on >= 1.19 servers.
-chat-signing: true
-
-# The threshold for packet compression. Packets larger than this size will be compressed. (-1 to disable)
-compression-threshold: 256
-
-# Enabling this will allow you to ping <= b1.7.3 servers. This may cause issues with servers that block too frequent connections.
-allow-beta-pinging: false
-
-# Enabling this will prevent getting disconnected from the server when a packet translation error occurs and instead only print the error in the console.
-# This may cause issues depending on the type of packet which failed to translate.
-ignore-protocol-translation-errors: false
-
-# Enabling this will suppress client protocol errors to prevent lag when ViaProxy is getting spammed with invalid packets.
-# This may cause issues with debugging client connection issues because no error messages will be printed.
-suppress-client-protocol-errors: false
-
-# Allow <= 1.6.4 clients to connect through ViaProxy to the target server. (No protocol translation or packet handling)
-allow-legacy-client-passthrough: false
-
-# Allow additional information like player ip, player uuid to be passed through to the backend server.
-# This is typically used by proxies like BungeeCord and requires support from the backend server as well.
-bungeecord-player-info-passthrough: false
-
-# Custom MOTD to send when clients ping the proxy. Leave empty to use the target server's MOTD.
-custom-motd: ''
-
-# URL of a resource pack which clients can optionally download when connecting to the server. Leave empty to disable.
-# Example: http://example.com/resourcepack.zip
-resource-pack-url: ''
-
-# Allows clients to specify a target server and version using wildcard domains.
-# none: No wildcard domain handling.
-# public: Public wildcard domain handling. Intended for usage by external clients. (Example: address_port_version.viaproxy.127.0.0.1.nip.io)
-# internal: Internal wildcard domain handling. Intended for local usage by custom clients. (Example: original-handshake-address\7address:port\7version\7classic-mppass)
+target-address: 127.0.0.1 # unused on srv mode.
+target-version: 1.8.x # unused on srv mode.
+auth-method: OpenAuthMod
 wildcard-domain-handling: PUBLIC
-
-# Enables handling and rewriting of Simple Voice Chat mod packets.
-simple-voice-chat-support: false
-
-# Accepts resource packs from the server without showing a prompt to the client.
-# This is required for servers that require a resource pack, but the client can't load it due to version differences.
-fake-accept-resource-packs: false
 ```
 
-You have to replace ``<bind port>`` with the port you want ViaProxy to run on.\
-The ``auth-method: openauthmod`` is optional and enables the [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) authentication.\
+You have to replace ``0.0.0.0:<bind port>`` with the port you want ViaProxy to run on.\
+The ``auth-method: openauthmod`` is optional and enables the [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) authentication. for 1.19.4 users, see the caution below.\
 The ``target-address`` and ``target-version`` are required for ViaProxy to start but don't do anything in SRV mode.
-
+> [!CAUTION]
+> warning: auth-method: openauthmod will be non functional for 1.7, Vanilla 1.8-1.19.3, 1.19.4-1.21.1, and Bedrock Edition. Reason: OpenAuthMod is only available for 1.8. Forge or Fabric don't support Bedrock Edition. OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
 ### Connecting to ViaProxy in SRV mode
 To connect to ViaProxy in SRV mode you need a domain pointing to the IP of the server running ViaProxy.\
 The subdomain ``viaproxy.`` is required for it to work.\
@@ -121,14 +37,10 @@ lenni0451.net_39999_c0.30-cpe.viaproxy.127-0-0-1.nip.io
 
 If the domain of a server contains an underscore you currently can't connect to it since ViaProxy uses the underscore as a separator.
 
-#### Geyser - usage for Geyser-ViaProxy
-Requires a Geyser-Viaproxy installed on server side.
-join with `address_port_version.viaproxy.hostname` on Bedrock Client Side. 
 #### Geyser - usage for GeyserConnect
-use a public geyserconnect.
-This does not require Geyser-Viaproxy on Server Side.
-find a existing instance.
-join with `address_port_version.viaproxy.hostname` on GeyserConnect. (the Bedrock/Geyser Server requires Geyser-Viaproxy installed on server side.)
+find a existing instance of viaproxy.
+join with `address_port_version.viaproxy.hostname` on GeyserConnect. (turning on Bedrock/Geyser Server requires Geyser-Viaproxy installed on server side.).
+
 ## How to make a ViaProxy plugin
 ### viaproxy.yml
 ViaProxy plugins require a ``viaproxy.yml`` file in the root of the plugin jar.\

--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@ You have to replace ``0.0.0.0:<bind port>`` with the port you want ViaProxy to r
 The ``auth-method: openauthmod`` is optional and enables the [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) authentication. for 1.19.4 users, see the caution below.\
 The ``target-address`` and ``target-version`` are required for ViaProxy to start but don't do anything in SRV mode.
 > [!CAUTION]
-> warning: auth-method: openauthmod will be non functional for 1.7, Vanilla 1.8-1.19.3, 1.19.4-1.21.1, and Bedrock Edition. Reason: OpenAuthMod is only available for 1.8. Forge or Fabric don't support Bedrock Edition. OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
+> warning: auth-method: openauthmod will be not functional for 1.7-1.7.10, Vanilla 1.8-1.19.3, 1.19.4-1.21.1, and Bedrock Edition.\ Reason: 1.7-1.7.10: OpenAuthMod is only available for 1.8.\ Bedrock: Forge or Fabric don't support Bedrock Edition.\ OpenAuthMod discontinued before release of 1.19.4. use this option if you want to.
 ### Connecting to ViaProxy in SRV mode
 To connect to ViaProxy in SRV mode you need a domain pointing to the IP of the server running ViaProxy.\
 The subdomain ``viaproxy.`` is required for it to work.\

--- a/README.MD
+++ b/README.MD
@@ -4,15 +4,105 @@ This plugin is only needed if you want to host a public SRV mode proxy instance.
 
 ## SRV ViaProxy
 ### Running ViaProxy in SRV mode
-To use the SRV mode in ViaProxy you have to start it through the command line.\
-The command line arguments are as follows:
-````bash
-java -jar ViaProxy.jar -ba 0.0.0.0 -bp <bind port> -srv -oam_auth -a0 -v1.8.x
-````
+> [!CAUTION]
+> This Option is meaningless because there is no proper authentication method for 1.19.4+ as OpenAuthMod discontinued and because ViaProxy was open source for 1 year is easier to use on client without their help. 
+use this option if you want to.
+
+To use the SRV mode in ViaProxy you have to start it through the config.\
+The config:
+```
+# ViaProxy configuration file
+
+# The address ViaProxy should listen for connections.
+# This option is not reloadable.
+bind-address: 0.0.0.0:25568 # will translate to viaproxy.0-0-0-0.nip.io:25568
+
+# The address of the server ViaProxy should connect to.
+target-address: 0.0.0.0:25565 # This option is ignored as client handles it like <target-address>_<target-port>.viaproxy.<bind-address>.
+
+# The version ViaProxy should translate to. (See ViaProxy GUI for a list of versions)
+target-version: Auto Detect (1.7+ servers) # This option is ignored as client handles it like <target-address>_<target-port>_<target_version>.viaproxy.<bind-address>.
+
+# The connect timeout for backend server connections in milliseconds.
+connect-timeout: 8000
+
+# Proxy Online Mode allows you to see skins on online mode servers and use the signed chat features.
+# Enabling Proxy Online Mode requires your client to have a valid minecraft account.
+proxy-online-mode: false
+
+# The authentication method to use for joining the target server.
+# none: No authentication (Offline mode)
+# openauthmod: Requires the OpenAuthMod client mod (https://modrinth.com/mod/openauthmod)
+# account: Use an account for joining the target server. (Has to be configured in ViaProxy GUI)
+auth-method: OPENAUTHMOD # OPTIONAL.
+
+# The GUI account list index (0 indexed) of the account if the auth method is set to account.
+minecraft-account-index: 0
+
+# Use BetaCraft authentication for classic servers.
+# Enabling BetaCraft Auth allows you to join classic servers which have online mode enabled.
+betacraft-auth: false
+
+# URL of a SOCKS(4/5)/HTTP(S) proxy which will be used for backend server connections. Leave empty to connect directly.
+# Supported formats:
+# - type://address:port
+# - type://username:password@address:port
+backend-proxy-url: ''
+
+# Send HAProxy protocol messages to the target server.
+backend-haproxy: false
+
+# Read HAProxy protocol messages from client connections.
+frontend-haproxy: false
+
+# Enables sending signed chat messages on >= 1.19 servers.
+chat-signing: true
+
+# The threshold for packet compression. Packets larger than this size will be compressed. (-1 to disable)
+compression-threshold: 256
+
+# Enabling this will allow you to ping <= b1.7.3 servers. This may cause issues with servers that block too frequent connections.
+allow-beta-pinging: false
+
+# Enabling this will prevent getting disconnected from the server when a packet translation error occurs and instead only print the error in the console.
+# This may cause issues depending on the type of packet which failed to translate.
+ignore-protocol-translation-errors: false
+
+# Enabling this will suppress client protocol errors to prevent lag when ViaProxy is getting spammed with invalid packets.
+# This may cause issues with debugging client connection issues because no error messages will be printed.
+suppress-client-protocol-errors: false
+
+# Allow <= 1.6.4 clients to connect through ViaProxy to the target server. (No protocol translation or packet handling)
+allow-legacy-client-passthrough: false
+
+# Allow additional information like player ip, player uuid to be passed through to the backend server.
+# This is typically used by proxies like BungeeCord and requires support from the backend server as well.
+bungeecord-player-info-passthrough: false
+
+# Custom MOTD to send when clients ping the proxy. Leave empty to use the target server's MOTD.
+custom-motd: ''
+
+# URL of a resource pack which clients can optionally download when connecting to the server. Leave empty to disable.
+# Example: http://example.com/resourcepack.zip
+resource-pack-url: ''
+
+# Allows clients to specify a target server and version using wildcard domains.
+# none: No wildcard domain handling.
+# public: Public wildcard domain handling. Intended for usage by external clients. (Example: address_port_version.viaproxy.127.0.0.1.nip.io)
+# internal: Internal wildcard domain handling. Intended for local usage by custom clients. (Example: original-handshake-address\7address:port\7version\7classic-mppass)
+wildcard-domain-handling: PUBLIC
+
+# Enables handling and rewriting of Simple Voice Chat mod packets.
+simple-voice-chat-support: false
+
+# Accepts resource packs from the server without showing a prompt to the client.
+# This is required for servers that require a resource pack, but the client can't load it due to version differences.
+fake-accept-resource-packs: false
+```
 
 You have to replace ``<bind port>`` with the port you want ViaProxy to run on.\
-The ``-oam_auth`` argument is optional and enables the [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) authentication.\
-The ``-a0`` and ``-v1.8.x`` arguments are required for ViaProxy to start but don't do anything in SRV mode.
+The ``auth-method: openauthmod`` is optional and enables the [OpenAuthMod](https://github.com/RaphiMC/OpenAuthMod) authentication.\
+The ``target-address`` and ``target-version`` are required for ViaProxy to start but don't do anything in SRV mode.
 
 ### Connecting to ViaProxy in SRV mode
 To connect to ViaProxy in SRV mode you need a domain pointing to the IP of the server running ViaProxy.\
@@ -21,7 +111,7 @@ For local connections you can use ``viaproxy.127-0-0-1.nip.io``.
 
 To connect to a server through ViaProxy you have to prepend the ``server ip``, ``server port`` and ``version`` to your domain:
 ````
-<ip>_<port>_<version>.viaproxy.<domain>
+address_port_version.viaproxy.hostname
 ````
 
 For example to connect to ``lenni0451.net:39999`` with the version ``C0.30-CPE`` you can use:
@@ -31,6 +121,14 @@ lenni0451.net_39999_c0.30-cpe.viaproxy.127-0-0-1.nip.io
 
 If the domain of a server contains an underscore you currently can't connect to it since ViaProxy uses the underscore as a separator.
 
+#### Geyser - usage for Geyser-ViaProxy
+Requires a Geyser-Viaproxy installed on server side.
+join with `address_port_version.viaproxy.hostname` on Bedrock Client Side. 
+#### Geyser - usage for GeyserConnect
+use a public geyserconnect.
+This does not require Geyser-Viaproxy on Server Side.
+find a existing instance.
+join with `address_port_version.viaproxy.hostname` on GeyserConnect. (the Bedrock/Geyser Server requires Geyser-Viaproxy installed on server side.)
 ## How to make a ViaProxy plugin
 ### viaproxy.yml
 ViaProxy plugins require a ``viaproxy.yml`` file in the root of the plugin jar.\

--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ repositories {
 }
 
 dependencies {
-    implementation "net.raphimc:ViaProxy:3.2.2"
+    implementation "net.raphimc:ViaProxy:3.3.4"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ repositories {
 }
 
 dependencies {
-    implementation "net.raphimc:ViaProxy:3.3.4"
+    implementation "net.raphimc:ViaProxy:3.3.4-SNAPSHOT"
 }

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -23,7 +23,7 @@ public class KickMessageConfig {
     @Description({
             "kick message when the user tries to join using local address such as 192.168.35.1. you can use the Decoration Codes here using Section Symbol(§)."
     })
-    public static String kick = "§You can't connect to any local address.";
+    public static String kick = "§cYou can't connect to any local address.";
   
     public static void load() {
         try {

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -27,7 +27,7 @@ public class KickMessageConfig {
   
     public static void load() {
         try {
-            ConfigLoader<MultiLaunchConfig> configLoader = new ConfigLoader<>(MultiLaunchConfig.class);
+            ConfigLoader<KickMessageConfig> configLoader = new ConfigLoader<>(KickMessageConfig.class);
             configLoader.getConfigOptions().setResetInvalidOptions(true); //Reset invalid options to their default value
             configLoader.loadStatic(ConfigProvider.file(new File("multilaunch.yml")));
         } catch (Throwable t) {

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -23,7 +23,7 @@ public class MultiLaunchConfig {
     @Description({
             "kick message when the user tries to join using local address such as 192.168.35.1. you can use the Decoration Codes here using Section Symbol(§)."
     })
-    public static String kick = "";
+    public static String kick = "§You can't connect to any local address.";
   
     public static void load() {
         try {

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @OptConfig(header = {
         "Configuration for the NoLocalConnections ViaProxy plugin.",
-        "Used to block a Connection for Local Address alongside ViaProxy.",
+        "Used to block a Connection for Local Address Connections through ViaProxy(useful for address_port_version.viaproxy.hostname).",
         "",
         "Made by Lenni0451",
         "Source: https://github.com/ViaVersionAddons/NoLocalConnections"

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -21,7 +21,7 @@ public class MultiLaunchConfig {
 
     @Option("ServerJar")
     @Description({
-            "kick message when the user tries to join using local address such as 192.168.35.1. you can use the Color Codes here."
+            "kick message when the user tries to join using local address such as 192.168.35.1. you can use the Decoration Codes here using Section Symbol(§)."
     })
     public static String kick = "";
   

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -11,11 +11,11 @@ import java.io.File;
 import java.util.List;
 
 @OptConfig(header = {
-        "Configuration for the MultiLaunch ViaProxy plugin.",
-        "Used to launch a server jar alongside ViaProxy.",
+        "Configuration for the NoLocalConnections ViaProxy plugin.",
+        "Used to block a Connection for Local Address alongside ViaProxy.",
         "",
         "Made by Lenni0451",
-        "Source: https://github.com/ViaVersionAddons/ViaProxyMultiLaunch"
+        "Source: https://github.com/ViaVersionAddons/NoLocalConnections"
 })
 public class MultiLaunchConfig {
 

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -19,7 +19,7 @@ import java.util.List;
 })
 public class MultiLaunchConfig {
 
-    @Option("ServerJar")
+    @Option("kick")
     @Description({
             "kick message when the user tries to join using local address such as 192.168.35.1. you can use the Decoration Codes here using Section Symbol(§)."
     })

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -17,7 +17,7 @@ import java.util.List;
         "Made by Lenni0451",
         "Source: https://github.com/ViaVersionAddons/NoLocalConnections"
 })
-public class MultiLaunchConfig {
+public class KickMessageConfig {
 
     @Option("kick")
     @Description({

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -29,7 +29,7 @@ public class KickMessageConfig {
         try {
             ConfigLoader<KickMessageConfig> configLoader = new ConfigLoader<>(KickMessageConfig.class);
             configLoader.getConfigOptions().setResetInvalidOptions(true); //Reset invalid options to their default value
-            configLoader.loadStatic(ConfigProvider.file(new File("multilaunch.yml")));
+            configLoader.loadStatic(ConfigProvider.file(new File("kickmessage.yml")));
         } catch (Throwable t) {
             Logger.LOGGER.error("Unable to load kick message! turning off viaproxy...", t);
             System.exit(-1);

--- a/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/KickMessageConfig.java
@@ -1,0 +1,38 @@
+package net.lenni0451.nolocalconnections;
+
+import net.lenni0451.optconfig.ConfigLoader;
+import net.lenni0451.optconfig.annotations.Description;
+import net.lenni0451.optconfig.annotations.OptConfig;
+import net.lenni0451.optconfig.annotations.Option;
+import net.lenni0451.optconfig.provider.ConfigProvider;
+import net.raphimc.viaproxy.util.logging.Logger;
+
+import java.io.File;
+import java.util.List;
+
+@OptConfig(header = {
+        "Configuration for the MultiLaunch ViaProxy plugin.",
+        "Used to launch a server jar alongside ViaProxy.",
+        "",
+        "Made by Lenni0451",
+        "Source: https://github.com/ViaVersionAddons/ViaProxyMultiLaunch"
+})
+public class MultiLaunchConfig {
+
+    @Option("ServerJar")
+    @Description({
+            "kick message when the user tries to join using local address such as 192.168.35.1. you can use the Color Codes here."
+    })
+    public static String kick = "";
+  
+    public static void load() {
+        try {
+            ConfigLoader<MultiLaunchConfig> configLoader = new ConfigLoader<>(MultiLaunchConfig.class);
+            configLoader.getConfigOptions().setResetInvalidOptions(true); //Reset invalid options to their default value
+            configLoader.loadStatic(ConfigProvider.file(new File("multilaunch.yml")));
+        } catch (Throwable t) {
+            Logger.LOGGER.error("Unable to load kick message! turning off viaproxy...", t);
+            System.exit(-1);
+        }
+    }
+}

--- a/src/main/java/net/lenni0451/nolocalconnections/Main.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/Main.java
@@ -18,7 +18,7 @@ public class Main extends ViaProxyPlugin {
     @EventHandler
     public void onEvent(PreConnectEvent event) {
         if (!(event.getServerAddress() instanceof InetSocketAddress socketAddress)) return;
-        if (this.isLocal(socketAddress.getAddress())) event.setCancelMessage("§cYou can't connect to any local address");
+        if (this.isLocal(socketAddress.getAddress())) event.setCancelMessage("§cConnection Cancelled! You are not allowed to connect to any local address!");
     }
 
     private boolean isLocal(final InetAddress address) {

--- a/src/main/java/net/lenni0451/nolocalconnections/Main.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/Main.java
@@ -12,13 +12,14 @@ public class Main extends ViaProxyPlugin {
 
     @Override
     public void onEnable() {
+        KickMessageConfig.load();
         ViaProxy.EVENT_MANAGER.register(this);
     }
 
     @EventHandler
     public void onEvent(PreConnectEvent event) {
         if (!(event.getServerAddress() instanceof InetSocketAddress socketAddress)) return;
-        if (this.isLocal(socketAddress.getAddress())) event.setCancelMessage("§cConnection Cancelled! You are not allowed to connect to any local address!");
+        if (this.isLocal(socketAddress.getAddress())) event.setCancelMessage(KickMessageConfig.kick);
     }
 
     private boolean isLocal(final InetAddress address) {

--- a/src/main/java/net/lenni0451/nolocalconnections/Main.java
+++ b/src/main/java/net/lenni0451/nolocalconnections/Main.java
@@ -1,5 +1,6 @@
 package net.lenni0451.nolocalconnections;
 
+import net.lenni0451.nolocalconnections.KickMessageConfig;
 import net.lenni0451.lambdaevents.EventHandler;
 import net.raphimc.viaproxy.ViaProxy;
 import net.raphimc.viaproxy.plugins.ViaProxyPlugin;


### PR DESCRIPTION
Please note that Public SRV mode With OpenAuthMod is No Longer Functional for 1.19.4-1.21.1+ as openauthmod is discontinued, making 1.19.4+ have no appopriate authentication method in CLI.(i attempted to create one, see #1. people will use the viaaas for 1.19.4 unless the server installed GeyserBlockJavaPlayers...)
the SRV mode is inside on wildcard-domain-handling: PUBLIC.
the Latest version of ViaProxy is 3.3.4-SNAPSHOT
the stable one is 3.3.3.